### PR TITLE
moved return statement out of the conditional block

### DIFF
--- a/client/feed/feed.js
+++ b/client/feed/feed.js
@@ -127,9 +127,8 @@ Template.messageModal.helpers({
 					window.Crusoe.img = img;
 				});
 			}
-
-			return message;
 		}
+		return message;
 	}
 });
 


### PR DESCRIPTION
One change that fixes the bug introduced with previous pull request. Only messages with photos were displaying because the return statement in message helper was inside a conditional block.
